### PR TITLE
Bduran/normalize install after versioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/turbo-tools",
-  "version": "2.0.6-beta.2",
+  "version": "2.0.6-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/turbo-tools",
-      "version": "2.0.6-beta.2",
+      "version": "2.0.6-beta.3",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/turbo-tools",
-  "version": "2.0.6-beta.1",
+  "version": "2.0.6-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/turbo-tools",
-      "version": "2.0.6-beta.1",
+      "version": "2.0.6-beta.2",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/turbo-tools",
-  "version": "2.0.6-beta.0",
+  "version": "2.0.6-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/turbo-tools",
-      "version": "2.0.6-beta.0",
+      "version": "2.0.6-beta.1",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/turbo-tools",
-  "version": "2.0.5",
+  "version": "2.0.6-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/turbo-tools",
-      "version": "2.0.5",
+      "version": "2.0.6-beta.0",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "A collection of TurboRepo CLI tools to test, lint, build, version and publish packages in your Turborepo monorepo",
   "name": "@better-builds/turbo-tools",
-  "version": "2.0.5",
+  "version": "2.0.6-beta.0",
   "main": "./index.js",
   "bin": "./cli.js",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "A collection of TurboRepo CLI tools to test, lint, build, version and publish packages in your Turborepo monorepo",
   "name": "@better-builds/turbo-tools",
-  "version": "2.0.6-beta.0",
+  "version": "2.0.6-beta.1",
   "main": "./index.js",
   "bin": "./cli.js",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "A collection of TurboRepo CLI tools to test, lint, build, version and publish packages in your Turborepo monorepo",
   "name": "@better-builds/turbo-tools",
-  "version": "2.0.6-beta.1",
+  "version": "2.0.6-beta.2",
   "main": "./index.js",
   "bin": "./cli.js",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "A collection of TurboRepo CLI tools to test, lint, build, version and publish packages in your Turborepo monorepo",
   "name": "@better-builds/turbo-tools",
-  "version": "2.0.6-beta.2",
+  "version": "2.0.6-beta.3",
   "main": "./index.js",
   "bin": "./cli.js",
   "license": "MPL-2.0",

--- a/src/util.ts
+++ b/src/util.ts
@@ -274,7 +274,7 @@ export async function versionWithLerna({
     stdio: 'inherit',
   });
   execSyncFromRoot({
-    args: ['commit', '--amend', '-m', `"${lastCommitMessage}"`],
+    args: ['commit', '--amend', '-m', `"${lastCommitMessage}"`, '--no-verify'],
     cmd: 'git',
     stdio: 'inherit',
   });

--- a/src/util.ts
+++ b/src/util.ts
@@ -274,7 +274,7 @@ export async function versionWithLerna({
     stdio: 'inherit',
   });
   execSyncFromRoot({
-    args: ['--amend', '-m', lastCommitMessage],
+    args: ['--amend', '-m', `"${lastCommitMessage}"`],
     cmd: 'git',
     stdio: 'inherit',
   });

--- a/src/util.ts
+++ b/src/util.ts
@@ -274,7 +274,7 @@ export async function versionWithLerna({
     stdio: 'inherit',
   });
   execSyncFromRoot({
-    args: ['--amend', '-m', `"${lastCommitMessage}"`],
+    args: ['commit', '--amend', '-m', `"${lastCommitMessage}"`],
     cmd: 'git',
     stdio: 'inherit',
   });


### PR DESCRIPTION
The latest version of lerna, which is used exclusively for handling version bumps, does not seem to run `npm install` anymore. This PR addressed this by running install in whichever package manager is detected in the user's repository