### PR TITLE
Allowing for a custom changelog line formatter

### DIFF
--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -111,6 +111,7 @@ export async function publish(yargs) {
     uniqify,
     willPublish: true,
     yes,
+    changelogLineFormatter: turboToolsCustomConfig?.version?.changelogLineFormatter,
   });
 
   if (!success) return console.info('Version bumps were aborted');

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,8 @@
 /**
  * @typedef {import('type-fest').PackageJson} PackageJson
+ * @typedef {import('@better-builds/lets-version').ChangeLogLineFormatter} ChangeLogLineFormatter
  */
+
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -55,7 +57,7 @@ import path from 'path';
  */
 
 /**
- * @typedef GetCommanReturnType
+ * @typedef GetCommandReturnType
  * @property {string[]} args
  * @property {string} cmd
  */
@@ -73,7 +75,7 @@ import path from 'path';
  * @callback GetCommand
  * @param {CustomFncOpts} opts
  *
- * @returns {GetCommanReturnType}
+ * @returns {GetCommandReturnType}
  */
 
 /**
@@ -89,12 +91,19 @@ import path from 'path';
  */
 
 /**
+ * @typedef {Object} TurboToolVersionConfig
+ * @property {ChangeLogLineFormatter} changelogLineFormatter
+ */
+
+/**
  * @typedef {Object} TurboToolsConfig
  *
  *
  * @property {TurboToolsInitConfig} init
  *
  * @property {TurboToolsPublishConfig} publish
+ *
+ * @property {TurboToolVersionConfig} version
  */
 
 /**

--- a/src/util/versioning.js
+++ b/src/util/versioning.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('@better-builds/lets-version').ChangeLogLineFormatter} ChangeLogLineFormatter
+ */
+
 import { applyRecommendedBumpsByPackage } from '@better-builds/lets-version';
 
 /**
@@ -19,6 +23,7 @@ export function determinePublishTag(releaseAs) {
  * @property {boolean} willPublish
  * @property {boolean} yes
  * @property {boolean} uniqify
+ * @property {ChangeLogLineFormatter=} changelogLineFormatter
  */
 
 /**
@@ -36,6 +41,7 @@ export async function versionWithLetsVersion(opts) {
     {
       yes: opts.yes,
       dryRun: opts.dryRun,
+      changelogLineFormatter: opts.changelogLineFormatter,
     },
   );
 


### PR DESCRIPTION
Adding a config object to allow users to pass a custom changelog line formatter to opt out of the default.

This will be dependent on https://github.com/benduran/lets-version/pull/3