### PR TITLE
Bduran/downgrade turbo for linux ci issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.4.2-beta.0 (2023-10-31)
+
+### 🛠️ Fixes 🛠️
+
+- fix(deps): downgraded turbo to a version the will hopefully not explode on Linux-based CI with a turbo not found error (188fc00c3310cce5ae83a8a8cc0c0d3d85486820)
+
+---
+
 ## 5.4.1 (2023-10-23)
 
 ### 🛠️ Fixes 🛠️

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/turbo-tools",
-  "version": "5.4.1",
+  "version": "5.4.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/turbo-tools",
-      "version": "5.4.1",
+      "version": "5.4.2-beta.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@better-builds/lets-version": "^0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.4.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@better-builds/lets-version": "^0.7.6",
+        "@better-builds/lets-version": "^0.8.0",
         "@commitlint/cli": "^17.8.0",
         "@commitlint/config-conventional": "^17.8.0",
         "@npmcli/map-workspaces": "^3.0.4",
@@ -19,7 +19,7 @@
         "fast-glob": "^3.3.1",
         "fs-extra": "^11.1.1",
         "husky": "^8.0.3",
-        "turbo": "1.10.15",
+        "turbo": "1.10.12",
         "typescript": "^4.9.5",
         "yargs": "^17.7.2"
       },
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@better-builds/lets-version": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@better-builds/lets-version/-/lets-version-0.7.6.tgz",
-      "integrity": "sha512-CCgQBBGgK4yC6DyP78nBr1QkUa02knQ8cub2gG8tdO2xjtjMJbEHM7/ImLvqeWp1eukTJrwW8JrJi9nrfjbvbQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@better-builds/lets-version/-/lets-version-0.8.0.tgz",
+      "integrity": "sha512-buG3n5ghhnCcRZViJfkc8tJ8e+o1817HSMouePw0CXhRkvtmax/8SUl5/BcbRl8T5ze/dutiNugReflvAAKJag==",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.4",
         "app-root-path": "^3.1.0",
@@ -8721,25 +8721,26 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.15.tgz",
-      "integrity": "sha512-mKKkqsuDAQy1wCCIjCdG+jOCwUflhckDMSRoeBPcIL/CnCl7c5yRDFe7SyaXloUUkt4tUR0rvNIhVCcT7YeQpg==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.12.tgz",
+      "integrity": "sha512-WM3+jTfQWnB9W208pmP4oeehZcC6JQNlydb/ZHMRrhmQa+htGhWLCzd6Q9rLe0MwZLPpSPFV2/bN5egCLyoKjQ==",
+      "hasInstallScript": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.10.15",
-        "turbo-darwin-arm64": "1.10.15",
-        "turbo-linux-64": "1.10.15",
-        "turbo-linux-arm64": "1.10.15",
-        "turbo-windows-64": "1.10.15",
-        "turbo-windows-arm64": "1.10.15"
+        "turbo-darwin-64": "1.10.12",
+        "turbo-darwin-arm64": "1.10.12",
+        "turbo-linux-64": "1.10.12",
+        "turbo-linux-arm64": "1.10.12",
+        "turbo-windows-64": "1.10.12",
+        "turbo-windows-arm64": "1.10.12"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.15.tgz",
-      "integrity": "sha512-Sik5uogjkRTe1XVP9TC2GryEMOJCaKE2pM/O9uLn4koQDnWKGcLQv+mDU+H+9DXvKLnJnKCD18OVRkwK5tdpoA==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.12.tgz",
+      "integrity": "sha512-vmDfGVPl5/aFenAbOj3eOx3ePNcWVUyZwYr7taRl0ZBbmv2TzjRiFotO4vrKCiTVnbqjQqAFQWY2ugbqCI1kOQ==",
       "cpu": [
         "x64"
       ],
@@ -8749,9 +8750,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.15.tgz",
-      "integrity": "sha512-xwqyFDYUcl2xwXyGPmHkmgnNm4Cy0oNzMpMOBGRr5x64SErS7QQLR4VHb0ubiR+VAb8M+ECPklU6vD1Gm+wekg==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.12.tgz",
+      "integrity": "sha512-3JliEESLNX2s7g54SOBqqkqJ7UhcOGkS0ywMr5SNuvF6kWVTbuUq7uBU/sVbGq8RwvK1ONlhPvJne5MUqBCTCQ==",
       "cpu": [
         "arm64"
       ],
@@ -8761,9 +8762,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.15.tgz",
-      "integrity": "sha512-dM07SiO3RMAJ09Z+uB2LNUSkPp3I1IMF8goH5eLj+d8Kkwoxd/+qbUZOj9RvInyxU/IhlnO9w3PGd3Hp14m/nA==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.12.tgz",
+      "integrity": "sha512-siYhgeX0DidIfHSgCR95b8xPee9enKSOjCzx7EjTLmPqPaCiVebRYvbOIYdQWRqiaKh9yfhUtFmtMOMScUf1gg==",
       "cpu": [
         "x64"
       ],
@@ -8773,9 +8774,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.15.tgz",
-      "integrity": "sha512-MkzKLkKYKyrz4lwfjNXH8aTny5+Hmiu4SFBZbx+5C0vOlyp6fV5jZANDBvLXWiDDL4DSEAuCEK/2cmN6FVH1ow==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.12.tgz",
+      "integrity": "sha512-K/ZhvD9l4SslclaMkTiIrnfcACgos79YcAo4kwc8bnMQaKuUeRpM15sxLpZp3xDjDg8EY93vsKyjaOhdFG2UbA==",
       "cpu": [
         "arm64"
       ],
@@ -8785,9 +8786,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.15.tgz",
-      "integrity": "sha512-3TdVU+WEH9ThvQGwV3ieX/XHebtYNHv9HARHauPwmVj3kakoALkpGxLclkHFBLdLKkqDvmHmXtcsfs6cXXRHJg==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.12.tgz",
+      "integrity": "sha512-7FSgSwvktWDNOqV65l9AbZwcoueAILeE4L7JvjauNASAjjbuzXGCEq5uN8AQU3U5BOFj4TdXrVmO2dX+lLu8Zg==",
       "cpu": [
         "x64"
       ],
@@ -8797,9 +8798,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.15.tgz",
-      "integrity": "sha512-l+7UOBCbfadvPMYsX08hyLD+UIoAkg6ojfH+E8aud3gcA1padpjCJTh9gMpm3QdMbKwZteT5uUM+wyi6Rbbyww==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.12.tgz",
+      "integrity": "sha512-gCNXF52dwom1HLY9ry/cneBPOKTBHhzpqhMylcyvJP0vp9zeMQQkt6yjYv+6QdnmELC92CtKNp2FsNZo+z0pyw==",
       "cpu": [
         "arm64"
       ],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "type-fest": "^3.12.0"
   },
   "dependencies": {
-    "@better-builds/lets-version": "^0.7.6",
+    "@better-builds/lets-version": "^0.8.0",
     "@commitlint/cli": "^17.8.0",
     "@commitlint/config-conventional": "^17.8.0",
     "@npmcli/map-workspaces": "^3.0.4",
@@ -56,7 +56,7 @@
     "fast-glob": "^3.3.1",
     "fs-extra": "^11.1.1",
     "husky": "^8.0.3",
-    "turbo": "1.10.15",
+    "turbo": "1.10.12",
     "typescript": "^4.9.5",
     "yargs": "^17.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "A collection of TurboRepo CLI tools to test, lint, build, version and publish packages in your Turborepo monorepo",
   "name": "@better-builds/turbo-tools",
-  "version": "5.4.1",
+  "version": "5.4.2-beta.0",
   "exports": "./dist/index.js",
   "bin": "./dist/cli.js",
   "type": "module",


### PR DESCRIPTION
hard pin to a slightly older version of TurboRepo that doesn't suffer from the dreaded "Turbo binary not found" issue that has been plaguing CI runs on our Linux VMs.