### PR TITLE
fix: change the order of arguments in publish execution

### DIFF
--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -96,7 +96,7 @@ export async function publish(yargs) {
   if (!skipTest) {
     execFromRoot({
       cmd: 'npx',
-      args: ['turbo', 'run', '--continue', 'test', filterArg],
+      args: ['turbo', 'run', 'test', '--continue', filterArg],
       stdio: 'inherit',
     });
   }
@@ -104,7 +104,7 @@ export async function publish(yargs) {
   if (!skipBuild) {
     execFromRoot({
       cmd: 'npx',
-      args: ['turbo', 'run', '--continue', 'build', filterArg],
+      args: ['turbo', 'run', 'build', '--continue', filterArg],
       stdio: 'inherit',
     });
   }


### PR DESCRIPTION
Hello, @benduran. 

We started to get the error using `--continue` with turbo version 2.4.4 ([here's where it is failing](https://github.com/benduran/turbo-tools/blob/99e9e55612c8ae8bb2fe3604881e12382032d0e6/src/commands/publish.js#L99 ))

The error we are getting is 
```bash
npx turbo run --continue test --filter="@prod-ops/delivery-list" --filter="@prod-ops/vertical-gantt" in /Users/vladkampov/netflix/prod-ops-ui
 ERROR  invalid value 'test' for '--continue [<CONTINUE>]'
  [possible values: never, dependencies-successful, always]

For more information, try '--help'.

node:internal/errors:984
  const err = new Error(message);
              ^

Error: Command failed: npx turbo run --continue test --filter="@prod-ops/delivery-list" --filter="@prod-ops/vertical-gantt"
```

It seems that with the change in turbo 2.4.4, turbo is strict about the order of the flags used.

Concern has been reported to the turbo maintainers: https://github.com/vercel/turborepo/pull/10023#issuecomment-2706199954
 
