### PR TITLE
bugfix(publish): pass saveExact and noFetchAll parameters to lets-version

### DIFF
--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -68,6 +68,8 @@ export async function publish(yargs) {
   const bumpInfos = await getRecommendedBumpsByPackage({
     force,
     names,
+    saveExact,
+    noFetchAll,
     noFetchTags,
     releaseAs,
     updateOptional,


### PR DESCRIPTION
Hey @benduran !

We have identified that some parameters were not being passed down to `lets-version`. This PR attempts to fix that so that the commands/args work properly.

On a separate note, there is also a `preid` field that is not defined at this part of the code. Depending on the current use case, we might be able to come back here and evaluate adding it, so for now, this is just a quick heads-up.